### PR TITLE
Add CI checks 

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,0 +1,30 @@
+name: API Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  build-and-checkstyle:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+      - name: Checkstyle
+        run: mvn checkstyle:check
+      - name: Build with Maven
+        run: mvn clean install
+      - run: mkdir staging && cp target/*.jar staging
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Package
+          path: staging


### PR DESCRIPTION
Добавил базовую настройку CI в проект для PR в main и dev, которая запускает:
* checkstyle проверку кода 
* успешное прохождение юнит тестов 
* по итогам проверки jar артефакт можно скачать для дебага (эту штуку не уверен, что нам надо, можем убрать)