### PR TITLE
Ментор ревью #3.5 (Фикс багов QA)

### DIFF
--- a/src/main/java/ru/yandex/workshop/main/dto/basket/OrdersListResponseDto.java
+++ b/src/main/java/ru/yandex/workshop/main/dto/basket/OrdersListResponseDto.java
@@ -1,0 +1,15 @@
+package ru.yandex.workshop.main.dto.basket;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class OrdersListResponseDto {
+    List<OrderResponseDto> orders;
+}

--- a/src/main/java/ru/yandex/workshop/main/dto/category/CategoriesListResponseDto.java
+++ b/src/main/java/ru/yandex/workshop/main/dto/category/CategoriesListResponseDto.java
@@ -1,0 +1,15 @@
+package ru.yandex.workshop.main.dto.category;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class CategoriesListResponseDto {
+    List<CategoryResponseDto> categories;
+}

--- a/src/main/java/ru/yandex/workshop/main/dto/error/ErrorResponse.java
+++ b/src/main/java/ru/yandex/workshop/main/dto/error/ErrorResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Getter
 public class ErrorResponse {
     private String message;
+    private String error;
     private String status;
     private LocalDateTime timestamp;
 }

--- a/src/main/java/ru/yandex/workshop/main/dto/error/ErrorResponse.java
+++ b/src/main/java/ru/yandex/workshop/main/dto/error/ErrorResponse.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 @Getter
 public class ErrorResponse {
     private String message;
-    private String reason;
     private String status;
     private LocalDateTime timestamp;
 }

--- a/src/main/java/ru/yandex/workshop/main/dto/product/ProductsListResponseDto.java
+++ b/src/main/java/ru/yandex/workshop/main/dto/product/ProductsListResponseDto.java
@@ -1,0 +1,15 @@
+package ru.yandex.workshop.main.dto.product;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ProductsListResponseDto {
+    List<ProductResponseDto> products;
+}

--- a/src/main/java/ru/yandex/workshop/main/dto/user/response/BuyersListResponseDto.java
+++ b/src/main/java/ru/yandex/workshop/main/dto/user/response/BuyersListResponseDto.java
@@ -1,0 +1,15 @@
+package ru.yandex.workshop.main.dto.user.response;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class BuyersListResponseDto {
+    List<BuyerResponseDto> buyers;
+}

--- a/src/main/java/ru/yandex/workshop/main/dto/user/response/FavouritesListResponseDto.java
+++ b/src/main/java/ru/yandex/workshop/main/dto/user/response/FavouritesListResponseDto.java
@@ -1,0 +1,15 @@
+package ru.yandex.workshop.main.dto.user.response;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class FavouritesListResponseDto {
+    List<FavoriteResponseDto> favorites;
+}

--- a/src/main/java/ru/yandex/workshop/main/dto/user/response/SellersListResponseDto.java
+++ b/src/main/java/ru/yandex/workshop/main/dto/user/response/SellersListResponseDto.java
@@ -1,0 +1,15 @@
+package ru.yandex.workshop.main.dto.user.response;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SellersListResponseDto {
+    List<SellerResponseDto> sellers;
+}

--- a/src/main/java/ru/yandex/workshop/main/dto/vendor/VendorsListResponseDto.java
+++ b/src/main/java/ru/yandex/workshop/main/dto/vendor/VendorsListResponseDto.java
@@ -1,0 +1,15 @@
+package ru.yandex.workshop.main.dto.vendor;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class VendorsListResponseDto {
+    List<VendorResponseDto> vendors;
+}

--- a/src/main/java/ru/yandex/workshop/main/exception/NotValidValueException.java
+++ b/src/main/java/ru/yandex/workshop/main/exception/NotValidValueException.java
@@ -1,7 +1,0 @@
-package ru.yandex.workshop.main.exception;
-
-public class NotValidValueException extends RuntimeException {
-    public NotValidValueException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/ru/yandex/workshop/main/mapper/BuyerMapper.java
+++ b/src/main/java/ru/yandex/workshop/main/mapper/BuyerMapper.java
@@ -4,7 +4,10 @@ import org.mapstruct.Mapper;
 import org.springframework.stereotype.Component;
 import ru.yandex.workshop.main.dto.user.BuyerUpdateDto;
 import ru.yandex.workshop.main.dto.user.response.BuyerResponseDto;
+import ru.yandex.workshop.main.dto.user.response.BuyersListResponseDto;
 import ru.yandex.workshop.main.model.buyer.Buyer;
+
+import java.util.List;
 
 @Mapper
 @Component
@@ -12,4 +15,8 @@ public interface BuyerMapper {
     BuyerResponseDto buyerToBuyerResponseDto(Buyer buyer);
 
     Buyer buyerDtoToBuyer(BuyerUpdateDto buyerUpdateDto);
+
+    default BuyersListResponseDto toBuyersListResponseDto(List<BuyerResponseDto> buyers) {
+        return BuyersListResponseDto.builder().buyers(buyers).build();
+    }
 }

--- a/src/main/java/ru/yandex/workshop/main/mapper/CategoryMapper.java
+++ b/src/main/java/ru/yandex/workshop/main/mapper/CategoryMapper.java
@@ -2,9 +2,12 @@ package ru.yandex.workshop.main.mapper;
 
 import org.mapstruct.Mapper;
 import org.springframework.stereotype.Component;
+import ru.yandex.workshop.main.dto.category.CategoriesListResponseDto;
 import ru.yandex.workshop.main.dto.category.CategoryCreateUpdateDto;
 import ru.yandex.workshop.main.dto.category.CategoryResponseDto;
 import ru.yandex.workshop.main.model.product.Category;
+
+import java.util.List;
 
 @Mapper
 @Component
@@ -13,4 +16,7 @@ public interface CategoryMapper {
 
     CategoryResponseDto categoryToCategoryResponseDto(Category category);
 
+    default CategoriesListResponseDto toCategoriesListResponseDto(List<CategoryResponseDto> categories) {
+        return CategoriesListResponseDto.builder().categories(categories).build();
+    }
 }

--- a/src/main/java/ru/yandex/workshop/main/mapper/FavoriteMapper.java
+++ b/src/main/java/ru/yandex/workshop/main/mapper/FavoriteMapper.java
@@ -4,11 +4,18 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.stereotype.Component;
 import ru.yandex.workshop.main.dto.user.response.FavoriteResponseDto;
+import ru.yandex.workshop.main.dto.user.response.FavouritesListResponseDto;
 import ru.yandex.workshop.main.model.buyer.Favorite;
+
+import java.util.List;
 
 @Mapper
 @Component
 public interface FavoriteMapper {
     @Mapping(target = "userId", source = "model.buyer.id")
     FavoriteResponseDto toFavouriteDto(Favorite model);
+
+    default FavouritesListResponseDto toFavouritesListResponseDto(List<FavoriteResponseDto> favorites) {
+        return FavouritesListResponseDto.builder().favorites(favorites).build();
+    }
 }

--- a/src/main/java/ru/yandex/workshop/main/mapper/ImageMapper.java
+++ b/src/main/java/ru/yandex/workshop/main/mapper/ImageMapper.java
@@ -4,7 +4,6 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import ru.yandex.workshop.main.dto.image.ImageDto;
 import ru.yandex.workshop.main.dto.image.ImageResponseDto;
 import ru.yandex.workshop.main.model.image.Image;
 

--- a/src/main/java/ru/yandex/workshop/main/mapper/ImageMapper.java
+++ b/src/main/java/ru/yandex/workshop/main/mapper/ImageMapper.java
@@ -21,8 +21,4 @@ public interface ImageMapper {
                 .path(String.valueOf(image.getId()))
                 .toUriString();
     }
-
-    ImageDto imageToImageDto(Image image);
-
-    Image imageDtoToImage(ImageDto imageDto);
 }

--- a/src/main/java/ru/yandex/workshop/main/mapper/OrderMapper.java
+++ b/src/main/java/ru/yandex/workshop/main/mapper/OrderMapper.java
@@ -2,10 +2,17 @@ package ru.yandex.workshop.main.mapper;
 
 import org.mapstruct.Mapper;
 import ru.yandex.workshop.main.dto.basket.OrderResponseDto;
+import ru.yandex.workshop.main.dto.basket.OrdersListResponseDto;
 import ru.yandex.workshop.main.model.buyer.Order;
+
+import java.util.List;
 
 @Mapper(uses = OrderPositionMapper.class)
 public interface OrderMapper {
 
     OrderResponseDto orderToOrderDto(Order order);
+
+    default OrdersListResponseDto toOrdersListResponseDto(List<OrderResponseDto> orders) {
+        return OrdersListResponseDto.builder().orders(orders).build();
+    }
 }

--- a/src/main/java/ru/yandex/workshop/main/mapper/OrderPositionMapper.java
+++ b/src/main/java/ru/yandex/workshop/main/mapper/OrderPositionMapper.java
@@ -9,6 +9,7 @@ import ru.yandex.workshop.main.model.buyer.OrderPosition;
 @Mapper(uses = ProductMapper.class)
 public interface OrderPositionMapper {
 
+    @Mapping(target = "id", ignore = true)
     OrderPosition basketPositionToOrderPosition(BasketPosition productBasket);
 
     @Mapping(target = "productResponseDto", source = "product")

--- a/src/main/java/ru/yandex/workshop/main/mapper/ProductMapper.java
+++ b/src/main/java/ru/yandex/workshop/main/mapper/ProductMapper.java
@@ -5,7 +5,10 @@ import org.mapstruct.Mapping;
 import org.springframework.stereotype.Component;
 import ru.yandex.workshop.main.dto.product.ProductCreateUpdateDto;
 import ru.yandex.workshop.main.dto.product.ProductResponseDto;
+import ru.yandex.workshop.main.dto.product.ProductsListResponseDto;
 import ru.yandex.workshop.main.model.product.Product;
+
+import java.util.List;
 
 @Mapper(uses = {ImageMapper.class, SellerMapper.class, VendorMapper.class})
 @Component
@@ -17,4 +20,7 @@ public interface ProductMapper {
 
     ProductResponseDto productToProductResponseDto(Product product);
 
+    default ProductsListResponseDto toProductsListResponseDto(List<ProductResponseDto> products) {
+        return ProductsListResponseDto.builder().products(products).build();
+    }
 }

--- a/src/main/java/ru/yandex/workshop/main/mapper/SellerMapper.java
+++ b/src/main/java/ru/yandex/workshop/main/mapper/SellerMapper.java
@@ -6,8 +6,11 @@ import org.springframework.stereotype.Component;
 import ru.yandex.workshop.main.dto.seller.BankRequisitesResponseDto;
 import ru.yandex.workshop.main.dto.user.SellerUpdateDto;
 import ru.yandex.workshop.main.dto.user.response.SellerResponseDto;
+import ru.yandex.workshop.main.dto.user.response.SellersListResponseDto;
 import ru.yandex.workshop.main.model.seller.BankRequisites;
 import ru.yandex.workshop.main.model.seller.Seller;
+
+import java.util.List;
 
 @Mapper(uses = ImageMapper.class)
 @Component
@@ -20,5 +23,9 @@ public interface SellerMapper {
     default BankRequisitesResponseDto requisitesToDto(BankRequisites requisites) {
         if (requisites == null) return null;
         return new BankRequisitesResponseDto(requisites.getId(), requisites.getAccount());
+    }
+
+    default SellersListResponseDto toSellersListResponseDto(List<SellerResponseDto> sellers) {
+        return SellersListResponseDto.builder().sellers(sellers).build();
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/mapper/VendorMapper.java
+++ b/src/main/java/ru/yandex/workshop/main/mapper/VendorMapper.java
@@ -4,7 +4,10 @@ import org.mapstruct.Mapper;
 import org.springframework.stereotype.Component;
 import ru.yandex.workshop.main.dto.vendor.VendorCreateUpdateDto;
 import ru.yandex.workshop.main.dto.vendor.VendorResponseDto;
+import ru.yandex.workshop.main.dto.vendor.VendorsListResponseDto;
 import ru.yandex.workshop.main.model.vendor.Vendor;
+
+import java.util.List;
 
 @Mapper(uses = ImageMapper.class)
 @Component
@@ -13,4 +16,8 @@ public interface VendorMapper {
     Vendor vendorDtoToVendor(VendorCreateUpdateDto vendorCreateUpdateDto);
 
     VendorResponseDto vendorToVendorResponseDto(Vendor vendor);
+
+    default VendorsListResponseDto toVendorsListResponseDto(List<VendorResponseDto> vendors) {
+        return VendorsListResponseDto.builder().vendors(vendors).build();
+    }
 }

--- a/src/main/java/ru/yandex/workshop/main/message/ExceptionMessage.java
+++ b/src/main/java/ru/yandex/workshop/main/message/ExceptionMessage.java
@@ -2,7 +2,7 @@ package ru.yandex.workshop.main.message;
 
 public enum ExceptionMessage {
     ENTITY_NOT_FOUND_EXCEPTION("Требуемая запись c ID (или email) %s и типом %s не найдена."),
-    DUPLICATE_EXCEPTION("Данная запись уже существует."),
+    DUPLICATE_EXCEPTION("Данная запись уже существует "),
     IMAGE_SIZE_EXCEED_EXCEPTION("Размер изображения должен не превышать 5 мб."),
     IMAGE_FORMAT_EXCEPTION("Формат изображения должен быть jpeg или png."),
     NO_IMAGE_CONTENT_EXCEPTION("Необходимо загрузить изображение."),

--- a/src/main/java/ru/yandex/workshop/main/message/ExceptionMessage.java
+++ b/src/main/java/ru/yandex/workshop/main/message/ExceptionMessage.java
@@ -1,7 +1,7 @@
 package ru.yandex.workshop.main.message;
 
 public enum ExceptionMessage {
-    ENTITY_NOT_FOUND_EXCEPTION("Требуемая запись не найдена."),
+    ENTITY_NOT_FOUND_EXCEPTION("Требуемая запись c ID (или email) %s и типом %s не найдена."),
     DUPLICATE_EXCEPTION("Данная запись уже существует."),
     IMAGE_SIZE_EXCEED_EXCEPTION("Размер изображения должен не превышать 5 мб."),
     IMAGE_FORMAT_EXCEPTION("Формат изображения должен быть jpeg или png."),
@@ -20,5 +20,10 @@ public enum ExceptionMessage {
 
     ExceptionMessage(String label) {
         this.label = label;
+    }
+
+    public String getMessage(String idOrEmail, Class<?> entityClass) {
+        String entityType = entityClass.getSimpleName();
+        return String.format(label, idOrEmail, entityType);
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/model/product/Product.java
+++ b/src/main/java/ru/yandex/workshop/main/model/product/Product.java
@@ -2,6 +2,7 @@ package ru.yandex.workshop.main.model.product;
 
 import lombok.*;
 import lombok.experimental.FieldDefaults;
+import org.hibernate.annotations.Cascade;
 import org.springframework.format.annotation.DateTimeFormat;
 import ru.yandex.workshop.main.model.image.Image;
 import ru.yandex.workshop.main.model.seller.Seller;
@@ -39,6 +40,7 @@ public class Product {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_id")
+    @Cascade(org.hibernate.annotations.CascadeType.DELETE)
     Image image;
 
     @OneToOne

--- a/src/main/java/ru/yandex/workshop/main/model/seller/Seller.java
+++ b/src/main/java/ru/yandex/workshop/main/model/seller/Seller.java
@@ -2,6 +2,7 @@ package ru.yandex.workshop.main.model.seller;
 
 import lombok.*;
 import lombok.experimental.FieldDefaults;
+import org.hibernate.annotations.Cascade;
 import org.springframework.format.annotation.DateTimeFormat;
 import ru.yandex.workshop.main.model.image.Image;
 
@@ -30,8 +31,10 @@ public class Seller {
     LocalDateTime registrationTime;
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "requisites_id")
+    @Cascade(org.hibernate.annotations.CascadeType.DELETE)
     BankRequisites requisites;
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_id")
+    @Cascade(org.hibernate.annotations.CascadeType.DELETE)
     Image image;
 }

--- a/src/main/java/ru/yandex/workshop/main/model/vendor/Vendor.java
+++ b/src/main/java/ru/yandex/workshop/main/model/vendor/Vendor.java
@@ -2,6 +2,7 @@ package ru.yandex.workshop.main.model.vendor;
 
 import lombok.*;
 import lombok.experimental.FieldDefaults;
+import org.hibernate.annotations.Cascade;
 import ru.yandex.workshop.main.model.image.Image;
 
 import javax.persistence.*;
@@ -22,6 +23,7 @@ public class Vendor {
     String description;
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_id")
+    @Cascade(org.hibernate.annotations.CascadeType.DELETE)
     Image image;
     @Enumerated(EnumType.STRING)
     Country country;

--- a/src/main/java/ru/yandex/workshop/main/service/admin/AdminService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/admin/AdminService.java
@@ -28,8 +28,9 @@ public class AdminService {
     public Admin getAdmin(String email) {
         return adminRepository
                 .findByEmail(email).orElseThrow(
-                        () -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label)
-                );
+                        () -> new EntityNotFoundException(
+                                ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(email, Admin.class)
+                        ));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ru/yandex/workshop/main/service/buyer/BasketService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/buyer/BasketService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ru.yandex.workshop.main.exception.EntityNotFoundException;
 import ru.yandex.workshop.main.exception.WrongConditionException;
 import ru.yandex.workshop.main.message.ExceptionMessage;
 import ru.yandex.workshop.main.model.buyer.Basket;
@@ -132,7 +133,10 @@ public class BasketService {
     public Basket getBasketOrThrowException(String email) {
         Buyer buyer = buyerService.getBuyerByEmail(email);
         Optional<Basket> basket = basketRepository.findByBuyerId(buyer.getId());
-        return basket.orElseThrow(() -> new NullPointerException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label));
+        return basket.orElseThrow(
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(email, Basket.class)
+                ));
     }
 
     public void removeBasketPosition(long basketPositionId) {

--- a/src/main/java/ru/yandex/workshop/main/service/buyer/BuyerFavoriteService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/buyer/BuyerFavoriteService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import ru.yandex.workshop.main.exception.DuplicateException;
 import ru.yandex.workshop.main.exception.EntityNotFoundException;
 import ru.yandex.workshop.main.message.ExceptionMessage;
+import ru.yandex.workshop.main.model.buyer.Buyer;
 import ru.yandex.workshop.main.model.buyer.Favorite;
 import ru.yandex.workshop.main.repository.buyer.FavoriteRepository;
 import ru.yandex.workshop.main.service.product.ProductService;
@@ -38,7 +39,9 @@ public class BuyerFavoriteService {
     @Transactional(readOnly = true)
     public List<Favorite> getAll(String buyerEmail) {
         if (!buyerService.checkIfUserExistsByEmail(buyerEmail))
-            throw new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label);
+            throw new EntityNotFoundException(
+                    ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(buyerEmail, Buyer.class)
+            );
         return favoriteRepository.findAllByBuyerEmail(buyerEmail);
     }
 

--- a/src/main/java/ru/yandex/workshop/main/service/buyer/BuyerService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/buyer/BuyerService.java
@@ -62,15 +62,17 @@ public class BuyerService {
     @Transactional(readOnly = true)
     public Buyer getBuyer(Long userId) {
         return buyerRepository.findById(userId).orElseThrow(
-                () -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label)
-        );
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(userId), Buyer.class)
+                ));
     }
 
     @Transactional(readOnly = true)
     public Buyer getBuyerByEmail(String email) {
-        return buyerRepository
-                .findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label));
+        return buyerRepository.findByEmail(email).orElseThrow(
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(email, Buyer.class)
+                ));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ru/yandex/workshop/main/service/buyer/OrderService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/buyer/OrderService.java
@@ -80,7 +80,7 @@ public class OrderService {
     }
 
     private void checkIfAvailable(BasketPosition basketPosition) {
-        if (basketPosition.getProduct().getQuantity() <= basketPosition.getQuantity())
+        if (basketPosition.getProduct().getQuantity() < basketPosition.getQuantity())
             throw new WrongConditionException("Товара у продавца осталось меньше, чем в заказе");
         if (basketPosition.getProduct().getProductStatus() != ProductStatus.PUBLISHED)
             throw new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label);

--- a/src/main/java/ru/yandex/workshop/main/service/buyer/OrderService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/buyer/OrderService.java
@@ -59,7 +59,9 @@ public class OrderService {
                     orderPositionList.add(orderPosition);
                     basketService.removeBasketPosition(productBasketId);
 
-                    productService.updateProductQuantityWhenOrder(positionInBasket.getProduct().getId());
+                    productService.updateProductQuantityWhenOrder(
+                            positionInBasket.getProduct().getId(),
+                            positionInBasket.getQuantity());
                     break;
                 }
                 if (i == basket.getProductsInBasket().size() - 1) {

--- a/src/main/java/ru/yandex/workshop/main/service/buyer/OrderService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/buyer/OrderService.java
@@ -72,6 +72,9 @@ public class OrderService {
                 }
             }
         }
+        if (orderPositionList.size() != basketPositionIds.size())
+            throw new WrongConditionException("Выбраны некорректные позиции товаров.");
+
         order.setProductsOrdered(orderPositionList);
         order.setOrderCost(wholePrice);
         Order orderSave = orderRepository.save(order);

--- a/src/main/java/ru/yandex/workshop/main/service/buyer/OrderService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/buyer/OrderService.java
@@ -89,7 +89,9 @@ public class OrderService {
     @Transactional(readOnly = true)
     public Order getOrder(Long orderId) {
         return orderRepository.findById(orderId).orElseThrow(() ->
-                new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label));
+                new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(orderId), Order.class)
+                ));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ru/yandex/workshop/main/service/image/ImageServiceImpl.java
+++ b/src/main/java/ru/yandex/workshop/main/service/image/ImageServiceImpl.java
@@ -62,7 +62,8 @@ public class ImageServiceImpl implements ImageService {
     @Transactional(readOnly = true)
     public Image getImageById(Long imageId) {
         return imageRepository.findById(imageId).orElseThrow(
-                () -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.name())
-        );
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(imageId), Image.class)
+                ));
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/service/product/CategoryServiceImpl.java
+++ b/src/main/java/ru/yandex/workshop/main/service/product/CategoryServiceImpl.java
@@ -41,8 +41,9 @@ public class CategoryServiceImpl implements CategoryService {
     @Transactional(readOnly = true)
     public Category getCategoryById(Long catId) {
         return repository.findById(catId).orElseThrow(
-                () -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label)
-        );
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(catId), Category.class)
+                ));
     }
 
     @Override

--- a/src/main/java/ru/yandex/workshop/main/service/product/ProductService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/product/ProductService.java
@@ -147,8 +147,10 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public Product getProductOrThrowException(Long productId) {
-        return productRepository.findById(productId)
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label));
+        return productRepository.findById(productId).orElseThrow(
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(productId), Product.class)
+                ));
     }
 
     private void initProduct(String sellerEmail, Product product, long categoryId, long vendorId) {
@@ -172,10 +174,14 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public Product getAvailableProduct(long productId) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label));
+        Product product = productRepository.findById(productId).orElseThrow(
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(productId), Product.class)
+                ));
         if (!product.getProductAvailability() || product.getProductStatus() != ProductStatus.PUBLISHED)
-            throw new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label);
+            throw new EntityNotFoundException(
+                    ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(productId), Product.class)
+            );
         return product;
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/service/product/ProductService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/product/ProductService.java
@@ -92,6 +92,12 @@ public class ProductService {
         return productRepository.save(product);
     }
 
+    public void updateProductQuantityWhenOrder(Long productId) {
+        Product product = getProductOrThrowException(productId);
+        product.setQuantity(product.getQuantity() - 1);
+        productRepository.save(product);
+    }
+
     public Product createProductImage(Long productId, MultipartFile file) {
         Product product = getProductOrThrowException(productId);
         if (product.getImage() != null) {

--- a/src/main/java/ru/yandex/workshop/main/service/product/ProductService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/product/ProductService.java
@@ -92,9 +92,9 @@ public class ProductService {
         return productRepository.save(product);
     }
 
-    public void updateProductQuantityWhenOrder(Long productId) {
+    public void updateProductQuantityWhenOrder(Long productId, Integer orderQuantity) {
         Product product = getProductOrThrowException(productId);
-        product.setQuantity(product.getQuantity() - 1);
+        product.setQuantity(product.getQuantity() - orderQuantity);
         productRepository.save(product);
     }
 

--- a/src/main/java/ru/yandex/workshop/main/service/product/SearchProductService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/product/SearchProductService.java
@@ -34,8 +34,10 @@ public class SearchProductService {
 
     @Transactional(readOnly = true)
     public Product getProductById(Long productId) {
-        return productRepository.findById(productId)
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label));
+        return productRepository.findById(productId).orElseThrow(
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(productId), Product.class)
+                ));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ru/yandex/workshop/main/service/seller/SellerBankService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/seller/SellerBankService.java
@@ -25,12 +25,14 @@ public class SellerBankService {
     public BankRequisites getRequisites(Long userId) {
         Seller seller = sellerService.getSeller(userId);
         if (seller.getRequisites() == null)
-            throw new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label);
+            throw new EntityNotFoundException(
+                    ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(userId), BankRequisites.class)
+            );
         return seller.getRequisites();
     }
 
     public BankRequisites updateRequisites(String email, BankRequisites requisites) {
-        Seller seller = getSellerFromDatabase(email);
+        Seller seller = sellerService.getSeller(email);
         if (seller.getRequisites() != null) {
             bankRepository.deleteById(seller.getRequisites().getId());
         }
@@ -39,16 +41,13 @@ public class SellerBankService {
     }
 
     public void deleteRequisites(String email) {
-        Seller seller = getSellerFromDatabase(email);
+        Seller seller = sellerService.getSeller(email);
         if (seller.getRequisites() == null)
-            throw new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label);
+            throw new EntityNotFoundException(
+                    ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(email, BankRequisites.class)
+            );
         bankRepository.delete(seller.getRequisites());
         seller.setRequisites(null);
         sellerRepository.save(seller);
-    }
-
-    private Seller getSellerFromDatabase(String email) {
-        return sellerRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label));
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/service/seller/SellerService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/seller/SellerService.java
@@ -71,7 +71,9 @@ public class SellerService {
 
     public void deleteSellerImageBySellerId(Long sellerId) {
         Seller seller = sellerRepository.findById(sellerId).orElseThrow(
-                () -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label));
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(sellerId), Seller.class)
+                ));
         if (seller.getImage() != null) {
             imageService.deleteImageById(seller.getImage().getId());
         }
@@ -86,14 +88,17 @@ public class SellerService {
     @Transactional(readOnly = true)
     public Seller getSeller(Long userId) {
         return sellerRepository.findById(userId).orElseThrow(
-                () -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label)
-        );
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(String.valueOf(userId), Seller.class)
+                ));
     }
 
     @Transactional(readOnly = true)
     public Seller getSeller(String email) {
-        return sellerRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label));
+        return sellerRepository.findByEmail(email).orElseThrow(
+                () -> new EntityNotFoundException(
+                        ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.getMessage(email, Seller.class)
+                ));
     }
 
     private boolean checkIfSellerExistsByEmail(String email) {

--- a/src/main/java/ru/yandex/workshop/main/web/controller/basket/BuyerOrderController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/basket/BuyerOrderController.java
@@ -8,6 +8,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import ru.yandex.workshop.main.dto.basket.OrderCreateDto;
 import ru.yandex.workshop.main.dto.basket.OrderResponseDto;
+import ru.yandex.workshop.main.dto.basket.OrdersListResponseDto;
 import ru.yandex.workshop.main.exception.EntityNotFoundException;
 import ru.yandex.workshop.main.exception.WrongConditionException;
 import ru.yandex.workshop.main.mapper.OrderMapper;
@@ -43,11 +44,12 @@ public class BuyerOrderController {
     @Operation(summary = "Список: Мои покупки", description = "Доступ для покупателя")
     @PreAuthorize("hasAuthority('buyer:write')")
     @GetMapping
-    public List<OrderResponseDto> getAllOrders(@ApiIgnore Principal principal) {
+    public OrdersListResponseDto getAllOrders(@ApiIgnore Principal principal) {
         log.debug(LogMessage.TRY_GET_ALL_ORDERS.label);
-        return orderService.getAllOrders(principal.getName()).stream()
+        List<OrderResponseDto> response = orderService.getAllOrders(principal.getName()).stream()
                 .map(orderMapper::orderToOrderDto)
                 .collect(Collectors.toList());
+        return OrdersListResponseDto.builder().orders(response).build();
     }
 
     @Operation(summary = "Получение конкретной покупки", description = "Доступ для покупателя")

--- a/src/main/java/ru/yandex/workshop/main/web/controller/basket/BuyerOrderController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/basket/BuyerOrderController.java
@@ -49,7 +49,7 @@ public class BuyerOrderController {
         List<OrderResponseDto> response = orderService.getAllOrders(principal.getName()).stream()
                 .map(orderMapper::orderToOrderDto)
                 .collect(Collectors.toList());
-        return OrdersListResponseDto.builder().orders(response).build();
+        return orderMapper.toOrdersListResponseDto(response);
     }
 
     @Operation(summary = "Получение конкретной покупки", description = "Доступ для покупателя")

--- a/src/main/java/ru/yandex/workshop/main/web/controller/product/CategoryController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/product/CategoryController.java
@@ -33,7 +33,7 @@ public class CategoryController {
         List<CategoryResponseDto> response = service.findCategoryAll().stream()
                 .map(categoryMapper::categoryToCategoryResponseDto)
                 .collect(Collectors.toList());
-        return CategoriesListResponseDto.builder().categories(response).build();
+        return categoryMapper.toCategoriesListResponseDto(response);
     }
 
     @Operation(summary = "Получение категории по id", description = "Доступ для всех")

--- a/src/main/java/ru/yandex/workshop/main/web/controller/product/CategoryController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/product/CategoryController.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import ru.yandex.workshop.main.dto.category.CategoriesListResponseDto;
 import ru.yandex.workshop.main.dto.category.CategoryCreateUpdateDto;
 import ru.yandex.workshop.main.dto.category.CategoryResponseDto;
 import ru.yandex.workshop.main.mapper.CategoryMapper;
@@ -27,12 +28,12 @@ public class CategoryController {
 
     @Operation(summary = "Получение списка категорий", description = "Доступ для всех")
     @GetMapping
-    public List<CategoryResponseDto> findAllCategories() {
+    public CategoriesListResponseDto findAllCategories() {
         log.debug(LogMessage.TRY_GET_CATEGORY.label);
-        List<Category> response = service.findCategoryAll();
-        return response.stream()
+        List<CategoryResponseDto> response = service.findCategoryAll().stream()
                 .map(categoryMapper::categoryToCategoryResponseDto)
                 .collect(Collectors.toList());
+        return CategoriesListResponseDto.builder().categories(response).build();
     }
 
     @Operation(summary = "Получение категории по id", description = "Доступ для всех")
@@ -58,7 +59,7 @@ public class CategoryController {
     @PreAuthorize("hasAuthority('admin:write')")
     @PatchMapping(path = "/{catId}")
     public CategoryResponseDto changeCategoryById(@PathVariable(name = "catId") Long catId,
-                                          @RequestBody @Valid CategoryCreateUpdateDto categoryCreateUpdateDto) {
+                                                  @RequestBody @Valid CategoryCreateUpdateDto categoryCreateUpdateDto) {
         log.debug(LogMessage.TRY_ADMIN_PATCH_CATEGORY.label, catId);
         Category updateRequest = categoryMapper.categoryDtoToCategory(categoryCreateUpdateDto);
         Category response = service.changeCategoryById(catId, updateRequest);

--- a/src/main/java/ru/yandex/workshop/main/web/controller/product/PublicProductController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/product/PublicProductController.java
@@ -48,6 +48,6 @@ public class PublicProductController {
         List<ProductResponseDto> response = productList.stream()
                 .map(productMapper::productToProductResponseDto)
                 .collect(Collectors.toList());
-        return ProductsListResponseDto.builder().products(response).build();
+        return productMapper.toProductsListResponseDto(response);
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/web/controller/product/PublicProductController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/product/PublicProductController.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import ru.yandex.workshop.main.dto.product.ProductResponseDto;
+import ru.yandex.workshop.main.dto.product.ProductsListResponseDto;
 import ru.yandex.workshop.main.dto.product.ProductsSearchRequestDto;
 import ru.yandex.workshop.main.dto.product.SortBy;
 import ru.yandex.workshop.main.mapper.ProductMapper;
@@ -37,15 +38,16 @@ public class PublicProductController {
 
     @Operation(summary = "Получение списка продуктов/поиск/фильтрация", description = "Доступ для всех")
     @GetMapping(path = "/search")
-    public List<ProductResponseDto> searchProducts(
+    public ProductsListResponseDto searchProducts(
             @RequestBody(required = false) @Valid ProductsSearchRequestDto productsSearchRequestDto,
             @RequestParam(name = "minId", defaultValue = "0") @Min(0) int minId,
             @RequestParam(name = "pageSize", defaultValue = "20") @Min(1) int pageSize,
             @RequestParam(name = "sort", defaultValue = "NEWEST") SortBy sort) {
         log.debug(LogMessage.TRY_GET_PRODUCTS_FILTER.label);
-        List<Product> response = productService.getProductsByFilter(productsSearchRequestDto, minId, pageSize, sort);
-        return response.stream()
+        List<Product> productList = productService.getProductsByFilter(productsSearchRequestDto, minId, pageSize, sort);
+        List<ProductResponseDto> response = productList.stream()
                 .map(productMapper::productToProductResponseDto)
                 .collect(Collectors.toList());
+        return ProductsListResponseDto.builder().products(response).build();
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/web/controller/product/UserProductController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/product/UserProductController.java
@@ -144,6 +144,6 @@ public class UserProductController {
         List<ProductResponseDto> response = productList.stream()
                 .map(productMapper::productToProductResponseDto)
                 .collect(Collectors.toList());
-        return ProductsListResponseDto.builder().products(response).build();
+        return productMapper.toProductsListResponseDto(response);
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/web/controller/product/UserProductController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/product/UserProductController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import ru.yandex.workshop.main.dto.product.ProductCreateUpdateDto;
 import ru.yandex.workshop.main.dto.product.ProductResponseDto;
+import ru.yandex.workshop.main.dto.product.ProductsListResponseDto;
 import ru.yandex.workshop.main.dto.validation.New;
 import ru.yandex.workshop.main.exception.WrongConditionException;
 import ru.yandex.workshop.main.mapper.ProductMapper;
@@ -135,13 +136,14 @@ public class UserProductController {
     @Operation(summary = "Получение списка товаров на модерацию", description = "Доступ для админа")
     @PreAuthorize("hasAuthority('admin:write')")
     @GetMapping(path = "/shipped")
-    public List<ProductResponseDto> getAllProductsShipped(
+    public ProductsListResponseDto getAllProductsShipped(
             @RequestParam(name = "minId", defaultValue = "0") @Min(0) int minId,
             @RequestParam(name = "pageSize", defaultValue = "20") @Min(1) int pageSize) {
         log.debug(LogMessage.TRY_GET_ALL_PRODUCTS_SHIPPED.label);
-        List<Product> response = productService.getAllProductsShipped(minId, pageSize);
-        return response.stream()
+        List<Product> productList = productService.getAllProductsShipped(minId, pageSize);
+        List<ProductResponseDto> response = productList.stream()
                 .map(productMapper::productToProductResponseDto)
                 .collect(Collectors.toList());
+        return ProductsListResponseDto.builder().products(response).build();
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/web/controller/user/BuyerController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/user/BuyerController.java
@@ -9,7 +9,9 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import ru.yandex.workshop.main.dto.user.BuyerUpdateDto;
 import ru.yandex.workshop.main.dto.user.response.BuyerResponseDto;
+import ru.yandex.workshop.main.dto.user.response.BuyersListResponseDto;
 import ru.yandex.workshop.main.dto.user.response.FavoriteResponseDto;
+import ru.yandex.workshop.main.dto.user.response.FavouritesListResponseDto;
 import ru.yandex.workshop.main.mapper.BuyerMapper;
 import ru.yandex.workshop.main.mapper.FavoriteMapper;
 import ru.yandex.workshop.main.message.LogMessage;
@@ -39,13 +41,14 @@ public class BuyerController {
     @Operation(summary = "Получение списка покупателей", description = "Доступ для админа")
     @PreAuthorize("hasAuthority('admin:write')")
     @GetMapping
-    public List<BuyerResponseDto> getAllBuyers(@RequestParam(name = "minId", defaultValue = "0") @Min(0) int minId,
-                                               @RequestParam(name = "pageSize", defaultValue = "20") @Min(1) int pageSize) {
+    public BuyersListResponseDto getAllBuyers(@RequestParam(name = "minId", defaultValue = "0") @Min(0) int minId,
+                                              @RequestParam(name = "pageSize", defaultValue = "20") @Min(1) int pageSize) {
         log.debug(LogMessage.TRY_GET_All_BUYERS.label);
-        List<Buyer> response = buyerService.getAllBuyers(minId, pageSize);
-        return response.stream()
+        List<Buyer> buyerList = buyerService.getAllBuyers(minId, pageSize);
+        List<BuyerResponseDto> response = buyerList.stream()
                 .map(buyerMapper::buyerToBuyerResponseDto)
                 .collect(Collectors.toList());
+        return BuyersListResponseDto.builder().buyers(response).build();
     }
 
     @PreAuthorize("hasAuthority('buyer:write') || hasAuthority('admin:write')")
@@ -90,11 +93,12 @@ public class BuyerController {
     @Operation(summary = "Просмотр избранных товаров", description = "Доступ для покупателя")
     @PreAuthorize("hasAuthority('buyer:write')")
     @GetMapping("/favorites")
-    public List<FavoriteResponseDto> getAll(@ApiIgnore Principal principal) {
+    public FavouritesListResponseDto getBuyerFavouriteProducts(@ApiIgnore Principal principal) {
         log.info(LogMessage.TRY_BUYER_GET_FAVORITE.label, principal.getName());
-        List<Favorite> response = favoriteService.getAll(principal.getName());
-        return response.stream()
+        List<Favorite> favoriteList = favoriteService.getAll(principal.getName());
+        List<FavoriteResponseDto> response = favoriteList.stream()
                 .map(favoriteMapper::toFavouriteDto)
                 .collect(Collectors.toList());
+        return FavouritesListResponseDto.builder().favorites(response).build();
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/web/controller/user/BuyerController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/user/BuyerController.java
@@ -48,7 +48,7 @@ public class BuyerController {
         List<BuyerResponseDto> response = buyerList.stream()
                 .map(buyerMapper::buyerToBuyerResponseDto)
                 .collect(Collectors.toList());
-        return BuyersListResponseDto.builder().buyers(response).build();
+        return buyerMapper.toBuyersListResponseDto(response);
     }
 
     @PreAuthorize("hasAuthority('buyer:write') || hasAuthority('admin:write')")
@@ -99,6 +99,6 @@ public class BuyerController {
         List<FavoriteResponseDto> response = favoriteList.stream()
                 .map(favoriteMapper::toFavouriteDto)
                 .collect(Collectors.toList());
-        return FavouritesListResponseDto.builder().favorites(response).build();
+        return favoriteMapper.toFavouritesListResponseDto(response);
     }
 }

--- a/src/main/java/ru/yandex/workshop/main/web/controller/user/SellerController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/user/SellerController.java
@@ -12,6 +12,7 @@ import ru.yandex.workshop.main.dto.seller.BankRequisitesCreateUpdateDto;
 import ru.yandex.workshop.main.dto.seller.BankRequisitesResponseDto;
 import ru.yandex.workshop.main.dto.user.SellerUpdateDto;
 import ru.yandex.workshop.main.dto.user.response.SellerResponseDto;
+import ru.yandex.workshop.main.dto.user.response.SellersListResponseDto;
 import ru.yandex.workshop.main.mapper.SellerMapper;
 import ru.yandex.workshop.main.message.LogMessage;
 import ru.yandex.workshop.main.model.seller.BankRequisites;
@@ -39,13 +40,14 @@ public class SellerController {
 
     @Operation(summary = "Получение списка продавцов", description = "Доступ для всех")
     @GetMapping
-    public List<SellerResponseDto> getAllSellers(@RequestParam(name = "minId", defaultValue = "0") @Min(0) int minId,
-                                                 @RequestParam(name = "pageSize", defaultValue = "20") @Min(1) int pageSize) {
+    public SellersListResponseDto getAllSellers(@RequestParam(name = "minId", defaultValue = "0") @Min(0) int minId,
+                                                @RequestParam(name = "pageSize", defaultValue = "20") @Min(1) int pageSize) {
         log.debug(LogMessage.TRY_GET_All_SELLERS.label);
-        List<Seller> response = sellerService.getAllSellers(minId, pageSize);
-        return response.stream()
+        List<Seller> sellerList = sellerService.getAllSellers(minId, pageSize);
+        List<SellerResponseDto> response = sellerList.stream()
                 .map(sellerMapper::sellerToSellerResponseDto)
                 .collect(Collectors.toList());
+        return SellersListResponseDto.builder().sellers(response).build();
     }
 
     @Operation(summary = "Получение конкретного продавца по userId", description = "Доступ для всех")

--- a/src/main/java/ru/yandex/workshop/main/web/controller/user/SellerController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/user/SellerController.java
@@ -47,7 +47,7 @@ public class SellerController {
         List<SellerResponseDto> response = sellerList.stream()
                 .map(sellerMapper::sellerToSellerResponseDto)
                 .collect(Collectors.toList());
-        return SellersListResponseDto.builder().sellers(response).build();
+        return sellerMapper.toSellersListResponseDto(response);
     }
 
     @Operation(summary = "Получение конкретного продавца по userId", description = "Доступ для всех")

--- a/src/main/java/ru/yandex/workshop/main/web/controller/vendor/VendorController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/vendor/VendorController.java
@@ -12,6 +12,7 @@ import ru.yandex.workshop.main.dto.validation.New;
 import ru.yandex.workshop.main.dto.vendor.VendorCreateUpdateDto;
 import ru.yandex.workshop.main.dto.vendor.VendorResponseDto;
 import ru.yandex.workshop.main.dto.vendor.VendorSearchRequestDto;
+import ru.yandex.workshop.main.dto.vendor.VendorsListResponseDto;
 import ru.yandex.workshop.main.mapper.VendorMapper;
 import ru.yandex.workshop.main.message.LogMessage;
 import ru.yandex.workshop.main.model.vendor.Vendor;
@@ -54,15 +55,16 @@ public class VendorController {
 
     @Operation(summary = "Получение списка вендоров с фильтрацией", description = "Доступ для всех")
     @GetMapping("/search")
-    public List<VendorResponseDto> findVendorWithFilers(
+    public VendorsListResponseDto findVendorWithFilers(
             @RequestBody(required = false) VendorSearchRequestDto vendorSearchRequestDto,
             @RequestParam(name = "minId", defaultValue = "0") @Min(0) int minId,
             @RequestParam(name = "pageSize", defaultValue = "20") @Min(1) int pageSize) {
         log.debug(LogMessage.TRY_GET_VENDORS.label);
-        List<Vendor> response = service.findVendorsWithFilter(vendorSearchRequestDto, minId, pageSize);
-        return response.stream()
+        List<Vendor> vendorList = service.findVendorsWithFilter(vendorSearchRequestDto, minId, pageSize);
+        List<VendorResponseDto> response = vendorList.stream()
                 .map(vendorMapper::vendorToVendorResponseDto)
                 .collect(Collectors.toList());
+        return VendorsListResponseDto.builder().vendors(response).build();
     }
 
     @Operation(summary = "Получение вендора по id", description = "Доступ для всех")

--- a/src/main/java/ru/yandex/workshop/main/web/controller/vendor/VendorController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/vendor/VendorController.java
@@ -64,7 +64,7 @@ public class VendorController {
         List<VendorResponseDto> response = vendorList.stream()
                 .map(vendorMapper::vendorToVendorResponseDto)
                 .collect(Collectors.toList());
-        return VendorsListResponseDto.builder().vendors(response).build();
+        return vendorMapper.toVendorsListResponseDto(response);
     }
 
     @Operation(summary = "Получение вендора по id", description = "Доступ для всех")

--- a/src/main/java/ru/yandex/workshop/main/web/handler/ErrorHandler.java
+++ b/src/main/java/ru/yandex/workshop/main/web/handler/ErrorHandler.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import ru.yandex.workshop.main.dto.error.ErrorResponse;
 import ru.yandex.workshop.main.exception.*;
-import ru.yandex.workshop.main.message.ExceptionMessage;
 import ru.yandex.workshop.security.exception.UnauthorizedException;
 import ru.yandex.workshop.security.exception.WrongDataDbException;
 import ru.yandex.workshop.security.exception.WrongRegException;
@@ -33,7 +32,6 @@ public class ErrorHandler {
         log.error(Arrays.toString(e.getStackTrace()));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.DUPLICATE_EXCEPTION.label)
                 .status(HttpStatus.CONFLICT.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -46,7 +44,6 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.WRONG_CONDITION_EXCEPTION.label)
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -59,7 +56,6 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.ENTITY_NOT_FOUND_EXCEPTION.label)
                 .status(HttpStatus.NOT_FOUND.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -72,7 +68,6 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.WRONG_CONDITION_EXCEPTION.label)
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -85,7 +80,6 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.UNAUTHORIZED_EXCEPTION.label)
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -102,7 +96,6 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.VALIDATION_EXCEPTION.label)
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -115,7 +108,6 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.ACCESS_EXCEPTION.label)
                 .status(HttpStatus.CONFLICT.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -128,7 +120,6 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.IMAGE_SERVER_UPLOAD_EXCEPTION.label)
                 .status(HttpStatus.INTERNAL_SERVER_ERROR.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -141,7 +132,6 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.IMAGE_FORMAT_EXCEPTION.label)
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -154,7 +144,6 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.DATA_EXCEPTION.label)
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -167,7 +156,6 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
-                .reason(ExceptionMessage.SIZE_EXCEPTION.label)
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();

--- a/src/main/java/ru/yandex/workshop/main/web/handler/ErrorHandler.java
+++ b/src/main/java/ru/yandex/workshop/main/web/handler/ErrorHandler.java
@@ -11,7 +11,6 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import ru.yandex.workshop.main.dto.error.ErrorResponse;
 import ru.yandex.workshop.main.exception.*;
 import ru.yandex.workshop.security.exception.UnauthorizedException;
-import ru.yandex.workshop.security.exception.WrongDataDbException;
 import ru.yandex.workshop.security.exception.WrongRegException;
 
 import java.time.LocalDateTime;
@@ -136,19 +135,6 @@ public class ErrorHandler {
     @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleImageFormatException(final ImageFormatException e) {
-        e.printStackTrace();
-        log.error(String.valueOf(e));
-        return ErrorResponse.builder()
-                .message(e.getMessage())
-                .error(e.getClass().getSimpleName())
-                .status(HttpStatus.BAD_REQUEST.toString())
-                .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
-                .build();
-    }
-
-    @ExceptionHandler
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ErrorResponse handleDbException(final WrongDataDbException e) {
         e.printStackTrace();
         log.error(String.valueOf(e));
         return ErrorResponse.builder()

--- a/src/main/java/ru/yandex/workshop/main/web/handler/ErrorHandler.java
+++ b/src/main/java/ru/yandex/workshop/main/web/handler/ErrorHandler.java
@@ -32,6 +32,7 @@ public class ErrorHandler {
         log.error(Arrays.toString(e.getStackTrace()));
         return ErrorResponse.builder()
                 .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
                 .status(HttpStatus.CONFLICT.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -44,6 +45,7 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -56,6 +58,7 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
                 .status(HttpStatus.NOT_FOUND.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -68,6 +71,7 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -80,6 +84,7 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -87,18 +92,19 @@ public class ErrorHandler {
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ErrorResponse handleValidationErrors(final MethodArgumentNotValidException e) {
+    public List<ErrorResponse> handleValidationErrors(final MethodArgumentNotValidException e) {
         e.printStackTrace();
-        List<String> details = new ArrayList<>();
+        List<ErrorResponse> details = new ArrayList<>();
         for (ObjectError error : e.getBindingResult().getAllErrors()) {
-            details.add(error.getDefaultMessage());
+            details.add(ErrorResponse.builder()
+                    .message(error.getDefaultMessage())
+                    .error(error.getClass().getSimpleName())
+                    .status(HttpStatus.BAD_REQUEST.toString())
+                    .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
+                    .build());
         }
         log.error(String.valueOf(e));
-        return ErrorResponse.builder()
-                .message(e.getMessage())
-                .status(HttpStatus.BAD_REQUEST.toString())
-                .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
-                .build();
+        return details;
     }
 
     @ExceptionHandler
@@ -108,6 +114,7 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
                 .status(HttpStatus.CONFLICT.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -120,6 +127,7 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
                 .status(HttpStatus.INTERNAL_SERVER_ERROR.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -132,6 +140,7 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -144,6 +153,7 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
@@ -156,6 +166,7 @@ public class ErrorHandler {
         log.error(String.valueOf(e));
         return ErrorResponse.builder()
                 .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
                 .status(HttpStatus.BAD_REQUEST.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();

--- a/src/main/java/ru/yandex/workshop/security/controller/AuthController.java
+++ b/src/main/java/ru/yandex/workshop/security/controller/AuthController.java
@@ -62,6 +62,7 @@ public class AuthController {
             String token = jwtTokenProvider.generateToken(request.getEmail(), user.getRole().name());
             response.put("email", user.getEmail());
             response.put("token", token);
+            response.put("role", user.getRole());
 
             return ResponseEntity.ok(response);
         } catch (AuthenticationException e) {

--- a/src/main/java/ru/yandex/workshop/security/exception/WrongDataDbException.java
+++ b/src/main/java/ru/yandex/workshop/security/exception/WrongDataDbException.java
@@ -1,7 +1,0 @@
-package ru.yandex.workshop.security.exception;
-
-public class WrongDataDbException extends java.sql.SQLException {
-    public WrongDataDbException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/ru/yandex/workshop/security/service/AuthService.java
+++ b/src/main/java/ru/yandex/workshop/security/service/AuthService.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.UnexpectedRollbackException;
 import org.springframework.transaction.annotation.Transactional;
 import ru.yandex.workshop.main.exception.DuplicateException;
 import ru.yandex.workshop.main.message.ExceptionMessage;
@@ -17,7 +18,6 @@ import ru.yandex.workshop.main.service.admin.AdminService;
 import ru.yandex.workshop.main.service.buyer.BuyerService;
 import ru.yandex.workshop.main.service.seller.SellerService;
 import ru.yandex.workshop.security.dto.UserCreateDto;
-import ru.yandex.workshop.security.exception.WrongDataDbException;
 import ru.yandex.workshop.security.mapper.UserMapper;
 import ru.yandex.workshop.security.model.Status;
 import ru.yandex.workshop.security.model.User;
@@ -36,7 +36,7 @@ public class AuthService {
     @Lazy
     private final PasswordEncoder passwordEncoder;
 
-    public User createNewUser(UserCreateDto userCreateDto) throws WrongDataDbException {
+    public User createNewUser(UserCreateDto userCreateDto) {
         if (checkIfUserExistsByEmail(userCreateDto.getEmail()))
             throw new DuplicateException(ExceptionMessage.DUPLICATE_EXCEPTION.label + userCreateDto.getEmail());
 
@@ -66,8 +66,8 @@ public class AuthService {
             }
 
             repository.save(userMapper.userDtoToUser(userCreateDto));
-        } catch (DataIntegrityViolationException e) {
-            throw new WrongDataDbException(e.getMessage());
+        } catch (DataIntegrityViolationException | UnexpectedRollbackException e) {
+            throw new DuplicateException(ExceptionMessage.DUPLICATE_EXCEPTION.label + userCreateDto.getPhone());
         }
 
         return user;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -125,7 +125,7 @@ CREATE TABLE IF NOT EXISTS "order"
     amount          FLOAT,
     buyer_id        BIGINT NOT NULL,
     CONSTRAINT pk_order PRIMARY KEY (id),
-    CONSTRAINT fk_order_buyer FOREIGN KEY (buyer_id) REFERENCES buyer (id)
+    CONSTRAINT fk_order_buyer FOREIGN KEY (buyer_id) REFERENCES buyer (id) on update cascade on delete cascade
 );
 
 CREATE TABLE IF NOT EXISTS statistic

--- a/src/test/java/ru/yandex/workshop/main/controller/basket/BuyerOrderControllerTest.java
+++ b/src/test/java/ru/yandex/workshop/main/controller/basket/BuyerOrderControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import ru.yandex.workshop.main.controller.CrudOperations;
 import ru.yandex.workshop.main.dto.basket.OrderCreateDto;
 import ru.yandex.workshop.main.dto.basket.OrderResponseDto;
+import ru.yandex.workshop.main.dto.basket.OrdersListResponseDto;
 import ru.yandex.workshop.main.dto.product.ProductResponseDto;
 
 import java.util.ArrayList;
@@ -140,9 +141,9 @@ class BuyerOrderControllerTest extends CrudOperations {
                 .andExpect(status().isOk())
                 .andReturn();
 
-        List<OrderResponseDto> orderResponseDtoList = List.of(objectMapper.readValue(
+        List<OrderResponseDto> orderResponseDtoList = objectMapper.readValue(
                 result.getResponse().getContentAsString(),
-                OrderResponseDto[].class));
+                OrdersListResponseDto.class).getOrders();
 
         assertEquals(2, orderResponseDtoList.size());
         assertEquals(1L, orderResponseDtoList.get(0).getId());

--- a/src/test/java/ru/yandex/workshop/main/controller/product/PublicProductControllerTest.java
+++ b/src/test/java/ru/yandex/workshop/main/controller/product/PublicProductControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import ru.yandex.workshop.main.controller.CrudOperations;
 import ru.yandex.workshop.main.dto.product.ProductResponseDto;
+import ru.yandex.workshop.main.dto.product.ProductsListResponseDto;
 import ru.yandex.workshop.main.dto.product.ProductsSearchRequestDto;
 import ru.yandex.workshop.main.model.vendor.Country;
 
@@ -57,7 +58,7 @@ class PublicProductControllerTest extends CrudOperations {
         ProductsSearchRequestDto productFilter = new ProductsSearchRequestDto();
         productFilter.setCategories(List.of(1L, 2L));
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto1, productResponseDto2, productResponseDto3);
         assertEquals(expect.size(), actual.size());
         assertEquals(expect.get(0).getName(), actual.get(0).getName());
@@ -72,7 +73,7 @@ class PublicProductControllerTest extends CrudOperations {
         ProductsSearchRequestDto productFilter = new ProductsSearchRequestDto();
         productFilter.setVendorIds(List.of(1L, 2L));
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto1, productResponseDto2);
         assertEquals(expect.size(), actual.size());
         assertEquals(expect.get(0).getName(), actual.get(0).getName());
@@ -86,7 +87,7 @@ class PublicProductControllerTest extends CrudOperations {
         ProductsSearchRequestDto productFilter = new ProductsSearchRequestDto();
         productFilter.setText("description and details");
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto3);
         assertEquals(expect.size(), actual.size());
         assertEquals(expect.get(0).getName(), actual.get(0).getName());
@@ -100,7 +101,7 @@ class PublicProductControllerTest extends CrudOperations {
         productFilter.setCategories(List.of(2L));
         productFilter.setVendorIds(List.of(2L));
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto2);
         assertEquals(expect.size(), actual.size());
         assertEquals(expect.get(0).getName(), actual.get(0).getName());
@@ -114,7 +115,7 @@ class PublicProductControllerTest extends CrudOperations {
         productFilter.setSellerIds(List.of(1L, 3L));
         productFilter.setText("pRoDucT");
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto1, productResponseDto3, productResponseDto5);
         assertEquals(expect.size(), actual.size());
         assertEquals(expect.get(0).getName(), actual.get(0).getName());
@@ -128,7 +129,7 @@ class PublicProductControllerTest extends CrudOperations {
         ProductsSearchRequestDto productFilter = new ProductsSearchRequestDto();
         productFilter.setCountries(List.of(Country.RUSSIA));
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto3, productResponseDto5);
         assertEquals(expect.size(), actual.size());
         assertEquals(expect.get(0).getName(), actual.get(0).getName());
@@ -141,7 +142,7 @@ class PublicProductControllerTest extends CrudOperations {
         ProductsSearchRequestDto productFilter = new ProductsSearchRequestDto();
         productFilter.setCountries(List.of(Country.USA));
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto1, productResponseDto2);
         assertEquals(expect.size(), actual.size());
         assertEquals(expect.get(0).getName(), actual.get(0).getName());
@@ -154,7 +155,7 @@ class PublicProductControllerTest extends CrudOperations {
         String sort = "NEWEST";
         ProductsSearchRequestDto productFilter = new ProductsSearchRequestDto();
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto1, productResponseDto2, productResponseDto3, productResponseDto5);
         assertEquals(expect.size(), actual.size());
         assertEquals(expect.get(0).getName(), actual.get(0).getName());
@@ -173,7 +174,7 @@ class PublicProductControllerTest extends CrudOperations {
         productFilter.setCategories(List.of(5L));
         productFilter.setCountries(List.of(Country.RUSSIA));
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = Lists.emptyList();
         assertEquals(actual, expect);
     }
@@ -184,7 +185,7 @@ class PublicProductControllerTest extends CrudOperations {
         String sort = "BY_PRICE";
         ProductsSearchRequestDto productFilter = new ProductsSearchRequestDto();
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto3, productResponseDto1, productResponseDto2, productResponseDto5);
         assertEquals(expect.size(), actual.size());
         assertEquals(expect.get(0).getName(), actual.get(0).getName());
@@ -200,7 +201,7 @@ class PublicProductControllerTest extends CrudOperations {
         productFilter.setPriceMin(1000F);
         productFilter.setPriceMax(2000F);
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto1, productResponseDto2);
         assertEquals(expect.size(), actual.size());
         assertEquals(expect.get(0).getName(), actual.get(0).getName());
@@ -214,7 +215,7 @@ class PublicProductControllerTest extends CrudOperations {
         ProductsSearchRequestDto productFilter = new ProductsSearchRequestDto();
         productFilter.setPriceMax(450F);
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = Lists.emptyList();
         assertEquals(actual, expect);
     }
@@ -226,12 +227,12 @@ class PublicProductControllerTest extends CrudOperations {
         ProductsSearchRequestDto productFilter = new ProductsSearchRequestDto();
         productFilter.setPriceMin(2000F);
 
-        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort);
+        List<ProductResponseDto> actual = getSearchResultsByFilter(productFilter, sort).getProducts();
         List<ProductResponseDto> expect = List.of(productResponseDto2);
         assertEquals(actual.get(0).getName(), expect.get(0).getName());
     }
 
-    private List<ProductResponseDto> getSearchResultsByFilter(ProductsSearchRequestDto productFilter, String sort) throws Exception {
+    private ProductsListResponseDto getSearchResultsByFilter(ProductsSearchRequestDto productFilter, String sort) throws Exception {
         MvcResult result = mockMvc.perform(get("/product/search")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(productFilter))
@@ -241,8 +242,8 @@ class PublicProductControllerTest extends CrudOperations {
                 .andExpect(status().isOk())
                 .andReturn();
 
-        return List.of(objectMapper.readValue(
+        return objectMapper.readValue(
                 result.getResponse().getContentAsString(),
-                ProductResponseDto[].class));
+                ProductsListResponseDto.class);
     }
 }

--- a/src/test/java/ru/yandex/workshop/main/controller/vendor/VendorControllerTest.java
+++ b/src/test/java/ru/yandex/workshop/main/controller/vendor/VendorControllerTest.java
@@ -12,10 +12,12 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import ru.yandex.workshop.main.controller.CrudOperations;
 import ru.yandex.workshop.main.dto.vendor.VendorCreateUpdateDto;
 import ru.yandex.workshop.main.dto.vendor.VendorResponseDto;
 import ru.yandex.workshop.main.dto.vendor.VendorSearchRequestDto;
+import ru.yandex.workshop.main.dto.vendor.VendorsListResponseDto;
 import ru.yandex.workshop.main.model.vendor.Country;
 
 import java.nio.charset.StandardCharsets;
@@ -81,15 +83,21 @@ class VendorControllerTest extends CrudOperations {
         vendorCreateUpdateDto.setCountry(Country.CHINA);
         VendorResponseDto response = createVendor(vendorCreateUpdateDto);
         VendorSearchRequestDto vendorFilter = new VendorSearchRequestDto("test", List.of(Country.CHINA));
-        List<VendorResponseDto> vendorResponseDtoList = List.of(response);
+        List<VendorResponseDto> expected = List.of(response);
 
-        mvc.perform(get("/vendor/search")
+        MvcResult result = mvc.perform(get("/vendor/search")
                         .characterEncoding(StandardCharsets.UTF_8)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(vendorFilter)))
                 .andExpect(status().isOk())
-                .andExpect(content().json(mapper.writeValueAsString(vendorResponseDtoList)));
+                .andReturn();
+
+        List<VendorResponseDto> actual = mapper.readValue(
+                result.getResponse().getContentAsString(),
+                VendorsListResponseDto.class).getVendors();
+
+        assertEquals(expected, actual);
     }
 
     @Test


### PR DESCRIPTION
* Добавлено условие каскад delete при удалении вендора / селлера / продукта по картинкам
* Добавлены отдельные DTO для работы с возвращаемыми списками List<...ResponseDto> для возращения ответа в виде:
```
{
"categories": [ {...} ]
}
```
* Поправил ENTITY_NOT_FOUND_EXCEPTION с указанием id и типа сущности, теперь возращается так:
```
{
    "message": "Требуемая запись c ID (или email) 10 и типом Vendor не найдена.",
    "error": "EntityNotFoundException",
    "status": "404 NOT_FOUND",
    "timestamp": "2023-11-22T14:31:47"
}
```
* Также немного поправил ErrorResponse и ErrorHandler, т.к. было дублирование в reason и message, и подкорректировал обработку MethodArgumentNotValidException при ошибках валидации
___

* Ошибка 500 при вводе одинаковых номеров и отсутствия номера заменена на 409
___

* Добавил небольшие правки по проверке при заказе
* Добавил новый метод обновления количества заказа, старый не подходит т.к. там статус меняется
