### PR TITLE
feature: add emails on create order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,12 @@
             <version>5.7.1</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+            <version>2.5.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/ru/yandex/workshop/main/dto/basket/OrderPositionResponseDto.java
+++ b/src/main/java/ru/yandex/workshop/main/dto/basket/OrderPositionResponseDto.java
@@ -1,9 +1,6 @@
 package ru.yandex.workshop.main.dto.basket;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import ru.yandex.workshop.main.dto.product.ProductResponseDto;
 
 @AllArgsConstructor

--- a/src/main/java/ru/yandex/workshop/main/message/EmailMessage.java
+++ b/src/main/java/ru/yandex/workshop/main/message/EmailMessage.java
@@ -1,0 +1,19 @@
+package ru.yandex.workshop.main.message;
+
+public enum EmailMessage {
+    ORDER_CONFIRM_SUBJECT("Подтверждение заказа №%d"),
+    ORDER_CONFIRM_EMAIL("Заказ №%d\n\n" +
+            "Дата: %s\n\n" +
+            "Описание заказанных товаров\n%s\n" +
+            "Имя покупателя: %s\n" +
+            "Телефон покупателя: %s\n" +
+            "Email покупателя: %s\n");
+
+    // TODO ... сообщения сброса пароля / регистрации и т.д.
+
+    public final String body;
+
+    EmailMessage(String message) {
+        this.body = message;
+    }
+}

--- a/src/main/java/ru/yandex/workshop/main/message/LogMessage.java
+++ b/src/main/java/ru/yandex/workshop/main/message/LogMessage.java
@@ -47,7 +47,8 @@ public enum LogMessage {
     TRY_GET_STATS_SELLER_ADMIN("Попытка получения статистики по продавцам админом"),
     TRY_GET_STATS_PRODUCT_ADMIN("Попытка получения статистики по продукту админом"),
     TRY_GET_STATS_PRODUCT_SELLER("Попытка получения статистики по продукту продавцом"),
-    TRY_CREATE_STATS("Попытка доздания статистики");
+    TRY_CREATE_STATS("Попытка доздания статистики"),
+    TRY_SEND_ORDER_CONFIRM_EMAIL("Попытка отправки email о созданнии заказа на email провадца");
 
 
     public final String label;

--- a/src/main/java/ru/yandex/workshop/main/model/buyer/OrderPosition.java
+++ b/src/main/java/ru/yandex/workshop/main/model/buyer/OrderPosition.java
@@ -28,4 +28,14 @@ public class OrderPosition {
     @Column(name = "amount")
     Float productCost;
     Boolean installation;
+
+    @Override
+    public String toString() {
+        String installString = installation ? "Да" : "Нет";
+        return  "\n" +
+                "Название товара: " + product.getName() + "\n" +
+                "Количество товара: " + quantity + " шт.\n" +
+                "Стоимость 1 единицы товара: " + productCost + " руб.\n" +
+                "Установка: " + installString + "\n";
+    }
 }

--- a/src/main/java/ru/yandex/workshop/main/service/buyer/OrderService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/buyer/OrderService.java
@@ -130,5 +130,4 @@ public class OrderService {
             statsService.createStats(stats);
         }
     }
-
 }

--- a/src/main/java/ru/yandex/workshop/main/service/email/EmailService.java
+++ b/src/main/java/ru/yandex/workshop/main/service/email/EmailService.java
@@ -1,0 +1,92 @@
+package ru.yandex.workshop.main.service.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+import ru.yandex.workshop.main.message.EmailMessage;
+import ru.yandex.workshop.main.model.buyer.Buyer;
+import ru.yandex.workshop.main.model.buyer.Order;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class EmailService {
+
+    @Value("${spring.mail.username}")
+    private String email;
+    private final JavaMailSender emailSender;
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public void sendOrderConfirmationEmails(Order order) {
+        long id = order.getId();
+        Buyer buyer = order.getBuyer();
+        LocalDateTime time = order.getProductionTime();
+        Map<String, List<String>> sellerEmailsAndText = new HashMap<>();
+
+        for (var orderPosition : order.getProductsOrdered()) {
+            String details = orderPosition.toString();
+            String email = orderPosition.getProduct().getSeller().getEmail();
+
+            List<String> textParts = sellerEmailsAndText.getOrDefault(email, new ArrayList<>());
+            textParts.add(details);
+            sellerEmailsAndText.put(email, textParts);
+        }
+
+        for (var entry : sellerEmailsAndText.entrySet()) {
+            String sellerEmail = entry.getKey();
+            String orderDescription = combineOrderPartsInSingleText(entry.getValue());
+            String text = getOrderConfirmEmailText(id, orderDescription, time, buyer);
+
+            SimpleMailMessage message = createEmailMessage(sellerEmail, text);
+            String emailSubject = String.format(EmailMessage.ORDER_CONFIRM_SUBJECT.body, id);
+            message.setSubject(emailSubject);
+
+            emailSender.send(message);
+        }
+    }
+
+    private SimpleMailMessage createEmailMessage(String to, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(email);
+        message.setTo(to);
+        message.setText(text);
+        message.setSentDate(Date.from(Instant.now()));
+        return message;
+    }
+
+    private String getOrderConfirmEmailText(long orderId,
+                                            String description,
+                                            LocalDateTime time,
+                                            Buyer buyer
+    ) {
+        return String.format(
+                EmailMessage.ORDER_CONFIRM_EMAIL.body,
+                orderId,
+                time.format(formatter),
+                description,
+                buyer.getName(),
+                buyer.getPhone(),
+                buyer.getEmail());
+    }
+
+    private String combineOrderPartsInSingleText(List<String> orderPositions) {
+        StringBuilder sb = new StringBuilder();
+        for (String positionDescription : orderPositions) {
+            sb.append(positionDescription).append("\n");
+        }
+        return sb.toString();
+    }
+
+    // TODO ... сброса пароля / регистрации и т.д.
+
+}

--- a/src/main/java/ru/yandex/workshop/main/web/controller/basket/BuyerOrderController.java
+++ b/src/main/java/ru/yandex/workshop/main/web/controller/basket/BuyerOrderController.java
@@ -15,6 +15,7 @@ import ru.yandex.workshop.main.mapper.OrderMapper;
 import ru.yandex.workshop.main.message.LogMessage;
 import ru.yandex.workshop.main.model.buyer.Order;
 import ru.yandex.workshop.main.service.buyer.OrderService;
+import ru.yandex.workshop.main.service.email.EmailService;
 import springfox.documentation.annotations.ApiIgnore;
 
 import java.security.Principal;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 public class BuyerOrderController {
     private final OrderService orderService;
     private final OrderMapper orderMapper;
+    private final EmailService emailService;
 
     @Operation(summary = "Оформление заказа", description = "Доступ для покупателя")
     @PreAuthorize("hasAuthority('buyer:write')")
@@ -38,6 +40,9 @@ public class BuyerOrderController {
         if (orderCreateDto.getBasketPositionIds() == null || orderCreateDto.getBasketPositionIds().size() == 0)
             throw new EntityNotFoundException("Перед оформлением заказа добавьте товары в корзину");
         Order response = orderService.createOrder(principal.getName(), orderCreateDto.getBasketPositionIds());
+
+        log.debug(LogMessage.TRY_SEND_ORDER_CONFIRM_EMAIL.label);
+        emailService.sendOrderConfirmationEmails(response);
         return orderMapper.orderToOrderDto(response);
     }
 

--- a/src/main/java/ru/yandex/workshop/main/web/handler/ErrorHandler.java
+++ b/src/main/java/ru/yandex/workshop/main/web/handler/ErrorHandler.java
@@ -13,6 +13,7 @@ import ru.yandex.workshop.main.exception.*;
 import ru.yandex.workshop.security.exception.UnauthorizedException;
 import ru.yandex.workshop.security.exception.WrongRegException;
 
+import javax.mail.SendFailedException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -154,6 +155,19 @@ public class ErrorHandler {
                 .message(e.getMessage())
                 .error(e.getClass().getSimpleName())
                 .status(HttpStatus.BAD_REQUEST.toString())
+                .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
+                .build();
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.GATEWAY_TIMEOUT)
+    public ErrorResponse handle(final SendFailedException e) {
+        e.printStackTrace();
+        log.error(String.valueOf(e));
+        return ErrorResponse.builder()
+                .message(e.getMessage())
+                .error(e.getClass().getSimpleName())
+                .status(HttpStatus.GATEWAY_TIMEOUT.toString())
                 .timestamp(LocalDateTime.parse(LocalDateTime.now().format(formatter), formatter))
                 .build();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,14 @@ spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=5MB
 spring.main.allow-bean-definition-overriding=true
+#Mail Server:
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=softplat.info@gmail.com
+spring.mail.password=hcyljijbimxqyalf
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
 #---
 spring.datasource.driverClassName=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://localhost:5432/postgres


### PR DESCRIPTION
Добавлена базовая настройка для отправки писем на email продавца при создании заказов.

Можно использовать в дальнейшем при настройки отправки писем при регистрации / сбросе пароля.

Покрытие тестами пока не придумал как сделать, но прогнал через Постман, получается что-то типа такого:
 
<img width="903" alt="Screenshot 2023-12-02 at 17 35 39" src="https://github.com/software-sales-and-installations/softplat-back/assets/118021621/19f81a3b-5121-42ef-b1cc-80a703534cd1">
